### PR TITLE
opam: remove the 'build' directive on dune dependency

### DIFF
--- a/uuuu.opam
+++ b/uuuu.opam
@@ -16,7 +16,7 @@ build: [
 
 depends: [
   "ocaml" {>= "4.03.0"}
-  "dune" {build}
+  "dune"
   "re" {>= "1.7.2"}
   "fmt"
   "bos"


### PR DESCRIPTION
This directive results in failure when downgrading Dune versions, due to version-specific functionality in the Dune language. See https://github.com/ocaml/opam/issues/3850 for more details.