### PR TITLE
Enable type inference for Menhir.

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 1.0)
+(lang dune 2.0)
 (name uuuu)
 (version dev)
-(using menhir 1.0)
+(using menhir 2.0)

--- a/src/dune
+++ b/src/dune
@@ -5,8 +5,8 @@
 
 (include dune.inc)
 
-(alias
- (name runtest)
+(rule
+ (alias runtest)
  (action (diff dune.inc dune.inc.gen)))
 
 (library


### PR DESCRIPTION
This is required for compatibility with Menhir 20211215.